### PR TITLE
Send params as querystring

### DIFF
--- a/lib/mango.rb
+++ b/lib/mango.rb
@@ -30,6 +30,12 @@ module Mango
 
     url = @api_base + url
 
+    if method == :get
+    querystring = ""
+    params.each { |k,v| querystring += "#{k}=#{v}&" }
+    url = url + '?' + querystring
+    end
+
     unless api_key ||= @api_key
       raise Error.new('No API key provided')
     end

--- a/lib/mango.rb
+++ b/lib/mango.rb
@@ -30,20 +30,17 @@ module Mango
 
     url = @api_base + url
 
-    if method == :get
-    querystring = ""
-    params.each { |k,v| querystring += "#{k}=#{v}&" }
-    url = url + '?' + querystring
-    end
-
     unless api_key ||= @api_key
       raise Error.new('No API key provided')
     end
 
     payload = JSON.generate(params) if method == :post || method == :patch
 
+    params = params if method == :get
+
     headers = {
-      :content_type => 'application/json'
+      :content_type => 'application/json',
+      :params => params
     }.merge(headers)
 
     options = {


### PR DESCRIPTION
If method is get, we should send params as querystring and not in the body as json (Now working only with post and patch).