### PR TITLE
Send querystring params on GET requests

### DIFF
--- a/lib/mango.rb
+++ b/lib/mango.rb
@@ -35,8 +35,10 @@ module Mango
     end
 
     payload = JSON.generate(params) if method == :post || method == :patch
+    params = nil unless method == :get
 
     headers = {
+      :params => params,
       :content_type => 'application/json'
     }.merge(headers)
 

--- a/test/mango_test.rb
+++ b/test/mango_test.rb
@@ -19,14 +19,20 @@ test "resource url" do
 end
 
 test "operation retrieve" do |mock|
-  mock.expects(:get).once.with('https://api.getmango.com/v1/customers/123/').returns(test_response(test_customer))
+  mock.expects(:get).once.with('https://api.getmango.com/v1/customers/123/', {}).returns(test_response(test_customer))
   customer = Mango::Customers.retrieve 123
   assert_equal "customer_hash", customer[:uid]
 end
 
 test "operation list" do |mock|
-  mock.expects(:get).once.with('https://api.getmango.com/v1/customers/').returns(test_response([test_customer]))
+  mock.expects(:get).once.with('https://api.getmango.com/v1/customers/', {}).returns(test_response([test_customer]))
   customers = Mango::Customers.list
+  assert_equal "customer_hash", customers.first[:uid]
+end
+
+test "aditional params on get" do |mock|
+  mock.expects(:get).once.with('https://api.getmango.com/v1/customers/', cardtype: 'visa').returns(test_response([test_customer]))
+  customers = Mango::Customers.list cardtype: 'visa'
   assert_equal "customer_hash", customers.first[:uid]
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,7 +8,7 @@ module Mango
   def self.execute_request(options)
     case options[:method]
     when :get
-      @mock_rest_client.get options[:url]
+      @mock_rest_client.get options[:url], options[:headers][:params]
     when :post
       @mock_rest_client.post options[:url], options[:payload]
     when :patch


### PR DESCRIPTION
Params passed to operations like `list` or `retrieve` will be send on the URL
```
customers = Mango::Customers.list cardtype: 'visa'
# => https://api.getmango.com/v1/customers/?cardtype=visa
```